### PR TITLE
Fix Access Token Retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Internet Game Database
+## 1.0.1
+- Fix a regression in which access tokens were being renewed with every request instead of on expiration.
+
 ## 1.0.0
 - BREAKING: Rename `IgdbClient::ApiClient` to `IgdbClient::Api`
 - BREAKING: Use keyword arguments for `IgdbClient::Api.new` instead of a hash

--- a/lib/igdb_client/api.rb
+++ b/lib/igdb_client/api.rb
@@ -18,10 +18,14 @@ module IgdbClient
 
       self.endpoint = Endpoint.validate(path)
 
-      Request.new.post(endpoint, query_builder)
+      request.post(endpoint, query_builder)
     end
 
     private
+
+    def request
+      @request ||= Request.new
+    end
 
     attr_accessor :endpoint, :query_builder
   end

--- a/lib/igdb_client/version.rb
+++ b/lib/igdb_client/version.rb
@@ -1,3 +1,3 @@
 module IgdbClient
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Fixes a regression that prevented the Twitch OAuth tokens from being re-used until expiration.