### PR TITLE
Return Single Item For Certain Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Internet Game Database
+## 2.0.0
+- BREAKING: Return `item` instead of `[item]` when an ID number is part of the `:get` request.
+- BREAKING: Return `item` instead of `[item]` when a `limit` of `1` is specified as part of the `:get` request.
+
 ## 1.0.1
 - Fix a regression in which access tokens were being renewed with every request instead of on expiration.
 
 ## 1.0.0
-- BREAKING: Rename `IgdbClient::ApiClient` to `IgdbClient::Api`
-- BREAKING: Use keyword arguments for `IgdbClient::Api.new` instead of a hash
-- Extract several utility classes from the core `IgdbClient::Api` class
+- BREAKING: Rename `IgdbClient::ApiClient` to `IgdbClient::Api`.
+- BREAKING: Use keyword arguments for `IgdbClient::Api.new` instead of a hash.
+- Extract several utility classes from the core `IgdbClient::Api` class.
 
 ## 0.1.0
-- Make search queries easier to use
-- Fix a bug with `missing_fields_parameter?` check
+- Make search queries easier to use.
+- Fix a bug with `missing_fields_parameter?` check.
 
 ## 0.0.1
-Initial Release
+Initial Release.

--- a/lib/igdb_client/api.rb
+++ b/lib/igdb_client/api.rb
@@ -18,7 +18,8 @@ module IgdbClient
 
       self.endpoint = Endpoint.validate(path)
 
-      request.post(endpoint, query_builder)
+      response = request.post(endpoint, query_builder)
+      query_builder.limit_to_one? ? response.first : response
     end
 
     private

--- a/lib/igdb_client/query/builder.rb
+++ b/lib/igdb_client/query/builder.rb
@@ -23,6 +23,10 @@ module IgdbClient
         @params[:id].field.present?
       end
 
+      def limit_to_one?
+        search_by_id? || @params[:limit].field == 'limit 1;'
+      end
+
       private
 
       def show_redundant_argument_warning

--- a/lib/igdb_client/version.rb
+++ b/lib/igdb_client/version.rb
@@ -1,3 +1,3 @@
 module IgdbClient
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/test/cases/api_test.rb
+++ b/test/cases/api_test.rb
@@ -29,6 +29,24 @@ class IgdbClient::ApiTest < ::Minitest::Test
         end
       end
 
+      it "returns an item instead of an array when 'id' is specified" do
+        VCR.use_cassette("list_of_game_names") do
+          game = subject.new.get(:games, fields: "name", id: 88308)
+          assert game.is_a?(OpenStruct)
+          assert game.id.present?
+          assert game.name.present?
+        end
+      end
+
+      it "returns an item instead of an array when 'limit == 1' is specified" do
+        VCR.use_cassette("list_of_game_names") do
+          game = subject.new.get(:games, fields: "name", limit: 1)
+          assert game.is_a?(OpenStruct)
+          assert game.id.present?
+          assert game.name.present?
+        end
+      end
+
       it "raises an error if the requested endpoint is not valid" do
         assert_raises(::IgdbClient::Endpoint::Invalid, "\"invalid_endpoint\" is not a recognized request.") do
           subject.new.get(:invalid_endpoint)


### PR DESCRIPTION
When using `id` or `limit: 1` it probably makes sense to just return the found item instead of wrapping it in an array.  This PR does that.