### PR TITLE
Support Field-Exclusion Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Internet Game Database
+
+## 2.2.0
+- Support querying fields with a comma-separated exclusion list.  For example:
+
+```ruby
+IgdbClient::Api.new.get(:games, exclude: "screenshots,websites")
+```
+
+This returns all fields _except_ the screenshots and websites arrays.
+
 ## 2.1.0
 - Support searching for multiple IDs in a single query.  For example:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ client.get(:games, fields: "name,aggregated_rating,hypes")
 => # Returns 10 games with only their ID, name, aggregated_rating, and hypes.
 ```
 
-You can specify expanded attributes for associated fiels with dot-notation (`.`):
+Alternatively you can exclude specific fields with a comma-separated string:
+
+```ruby
+client = IgdbClient::Api.new
+client.get(:games, exclude: "screenshots,websites")
+=> # Returns 10 games with all fields EXCEPT the 'screenshots' and 'websites' fields
+```
+
+You can specify expanded attributes for associated fields with dot-notation (`.`):
 ```ruby
 client = IgdbClient::Api.new
 client.get(:games, fields: "name, platforms.*")

--- a/lib/igdb_client.rb
+++ b/lib/igdb_client.rb
@@ -13,14 +13,15 @@ module IgdbClient
   end
 
   module Query
-    autoload :Builder, "igdb_client/query/builder"
+    autoload :Builder,   "igdb_client/query/builder"
 
     module Fields
-      autoload :Base,   "igdb_client/query/fields/base"
-      autoload :Field,  "igdb_client/query/fields/field"
-      autoload :Id,     "igdb_client/query/fields/id"
-      autoload :Limit,  "igdb_client/query/fields/limit"
-      autoload :Search, "igdb_client/query/fields/search"
+      autoload :Base,    "igdb_client/query/fields/base"
+      autoload :Exclude, "igdb_client/query/fields/exclude"
+      autoload :Field,   "igdb_client/query/fields/field"
+      autoload :Id,      "igdb_client/query/fields/id"
+      autoload :Limit,   "igdb_client/query/fields/limit"
+      autoload :Search,  "igdb_client/query/fields/search"
     end
   end
 

--- a/lib/igdb_client/api.rb
+++ b/lib/igdb_client/api.rb
@@ -8,10 +8,11 @@ module IgdbClient
       "Available endpoints: #{Constants::Endpoints::ALL.join(", ")}"
     end
 
-    def get(path, fields: "*", id: nil, search: nil, limit: nil)
+    def get(path, fields: "*", exclude: nil, id: nil, search: nil, limit: nil)
       self.query_builder =
         Query::Builder.new(
           fields: fields,
+          exclude: exclude,
           id: id,
           search: search,
           limit: limit)

--- a/lib/igdb_client/query/builder.rb
+++ b/lib/igdb_client/query/builder.rb
@@ -5,6 +5,7 @@ module IgdbClient
 
       def initialize(fields: "*", exclude: nil, id: nil, search: nil, limit: nil)
         raise InvalidArguments, "Cannot combine ID with Search" if id.present? && search.present?
+        raise InvalidArguments, "Cannot combine Fields with Exclude" if fields != "*" && exclude.present?
         show_redundant_argument_warning if id.present? && limit.present?
 
         @params = {

--- a/lib/igdb_client/query/builder.rb
+++ b/lib/igdb_client/query/builder.rb
@@ -3,12 +3,13 @@ module IgdbClient
     class Builder
       class InvalidArguments < StandardError; end
 
-      def initialize(fields: "*", id: nil, search: nil, limit: nil)
+      def initialize(fields: "*", exclude: nil, id: nil, search: nil, limit: nil)
         raise InvalidArguments, "Cannot combine ID with Search" if id.present? && search.present?
         show_redundant_argument_warning if id.present? && limit.present?
 
         @params = {
           fields: Fields::Field.new(fields),
+          exclude: Fields::Exclude.new(exclude),
           id: Fields::Id.new(id),
           search: Fields::Search.new(search),
           limit: Fields::Limit.new(limit)

--- a/lib/igdb_client/query/fields/base.rb
+++ b/lib/igdb_client/query/fields/base.rb
@@ -12,7 +12,7 @@ module IgdbClient
         end
 
         def build
-          raise NoMethodError, "stringify must be implemented by subclasses."
+          raise NoMethodError, "build must be implemented by subclasses."
         end
 
         protected

--- a/lib/igdb_client/query/fields/exclude.rb
+++ b/lib/igdb_client/query/fields/exclude.rb
@@ -1,0 +1,11 @@
+module IgdbClient
+  module Query
+    module Fields
+      class Exclude < ::IgdbClient::Query::Fields::Base
+        def build
+          @field = "exclude #{@value};"
+        end
+      end
+    end
+  end
+end

--- a/lib/igdb_client/version.rb
+++ b/lib/igdb_client/version.rb
@@ -1,3 +1,3 @@
 module IgdbClient
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/test/cases/query/builder_test.rb
+++ b/test/cases/query/builder_test.rb
@@ -21,6 +21,10 @@ module IgdbClient
             assert_equal subject.new(fields: "name,cover").build, "fields name,cover;"
           end
 
+          it "creates a query with a specific list of excluded fields" do
+            assert_equal subject.new(exclude: "screenshots,websites").build, "fields *;exclude screenshots,websites;"
+          end
+
           it "creates a query with a selected id and default field query without field arguments" do
             assert_equal subject.new(id: 7).build, "fields *;where id = (7);"
           end

--- a/test/cases/query/builder_test.rb
+++ b/test/cases/query/builder_test.rb
@@ -10,6 +10,12 @@ module IgdbClient
               subject.new(id: 7, search: "Sherlock Holmes")
             end
           end
+
+          it "raises an error when fields and exclude terms are combined" do
+            assert_raises(Builder::InvalidArguments) do
+              subject.new(fields: "name", exclude: "screenshots")
+            end
+          end
         end
 
         describe "#build" do

--- a/test/cases/query/fields/exclude_test.rb
+++ b/test/cases/query/fields/exclude_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+module IgdbClient
+  module Query
+    module Fields
+      class ExcludeTest < ::Minitest::Test
+
+        describe IgdbClient::Query::Fields::Exclude do
+          let(:subject) { IgdbClient::Query::Fields::Exclude }
+
+          describe "#field" do
+            it "returns a formatted string" do
+              assert_equal subject.new("screenshots,websites").field, "exclude screenshots,websites;"
+            end
+
+            it "returns an empty string if no input is provided" do
+              assert_empty subject.new.field
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes you may only want to exclude 1 or 2 fields from a query result.  Instead of building up a huge comma-separated list of fields we can just supply an `exclude` list instead.