### PR TITLE
Support Advanced Filtering & Querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Internet Game Database Client Changelog
 
+## 2.5.0
+- Support advanced filtering:
+```ruby
+IgdbClient::Api.new.get(:games, fields: "name", filter: "where rating >= 80")
+```
+
+See the official [IGDB#filters](https://api-docs.igdb.com/#filters) documentation for more details.
+
 ## 2.4.0
 - Support pagination feature with `offset` field:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ client.get(:games, limit: 15, search: "Super", sort_by: "aggregated_rating", sor
 
 Note that the `sort_direction` parameter is optional.  When not specified the default sort order is `:asc` (ascending).
 
+The client accepts advanced filtering as defined by the IGDB API:
+```ruby
+client = IgdbClient::Api.new
+client.get(:games, fields: "name", filter: "where rating >= 80")
+```
+
+See the [IGDB API Documentation for filters](https://api-docs.igdb.com/#filters) for more information.  The client does not currently perform any validations against the filter query.
+
 ### Other Notes
 As long as you hold a reference to the `IgdbClient::Api` in memory, it will manage authentication concerns w/Twitch automatically.
 The access token remains in memory until it expires at which point any subsequent request made through the client will silently reauthenticate and process the request.

--- a/lib/igdb_client.rb
+++ b/lib/igdb_client.rb
@@ -19,6 +19,7 @@ module IgdbClient
       autoload :Base,    "igdb_client/query/fields/base"
       autoload :Exclude, "igdb_client/query/fields/exclude"
       autoload :Field,   "igdb_client/query/fields/field"
+      autoload :Filter,  "igdb_client/query/fields/filter"
       autoload :Id,      "igdb_client/query/fields/id"
       autoload :Limit,   "igdb_client/query/fields/limit"
       autoload :Offset,  "igdb_client/query/fields/offset"

--- a/lib/igdb_client/api.rb
+++ b/lib/igdb_client/api.rb
@@ -9,8 +9,7 @@ module IgdbClient
     end
 
     def get(path, **opts)
-      self.query_builder =
-        Query::Builder.new(**opts)
+      self.query_builder = Query::Builder.new(**opts)
 
       self.endpoint = Endpoint.validate(path)
 

--- a/lib/igdb_client/query/builder.rb
+++ b/lib/igdb_client/query/builder.rb
@@ -8,6 +8,7 @@ module IgdbClient
       def initialize(**opts)
         @exclude   = opts[:exclude]
         @fields    = opts[:fields] || ALL_FIELDS
+        @filter    = opts[:filter]
         @id        = opts[:id]
         @limit     = opts[:limit]
         @offset    = opts[:offset]
@@ -43,6 +44,10 @@ module IgdbClient
           errors << "Cannot combine ID with Offset"
         end
 
+        if @id.present? && @filter.present?
+          errors << "Cannot combine ID with Filters"
+        end
+
         if errors.any?
           raise InvalidArguments, errors.join(", ")
         end
@@ -58,6 +63,7 @@ module IgdbClient
         {
           exclude: Fields::Exclude.new(@exclude),
           fields: Fields::Field.new(@fields),
+          filter: Fields::Filter.new(@filter),
           id: Fields::Id.new(@id),
           limit: Fields::Limit.new(@limit),
           offset: Fields::Offset.new(@offset),

--- a/lib/igdb_client/query/fields/filter.rb
+++ b/lib/igdb_client/query/fields/filter.rb
@@ -1,0 +1,11 @@
+module IgdbClient
+  module Query
+    module Fields
+      class Filter < Base
+        def build
+          @field = "#{@value};"
+        end
+      end
+    end
+  end
+end

--- a/lib/igdb_client/version.rb
+++ b/lib/igdb_client/version.rb
@@ -1,3 +1,3 @@
 module IgdbClient
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end

--- a/test/cases/query/builder_test.rb
+++ b/test/cases/query/builder_test.rb
@@ -23,6 +23,12 @@ module IgdbClient
             end
           end
 
+          it "raises an error when id and filter terms are combined" do
+            assert_raises(Builder::InvalidArguments) do
+              subject.new(id: 7, filter: "where rating >= 80")
+            end
+          end
+
           it "explains all the errors when multiple are present" do
             assert_raises(Builder::InvalidArguments, "Cannot combine ID with Search, Cannot combine Fields with Exclude, Cannot combine ID with Offset") do
               subject.new(id: 1103, search: "Super", fields: "name,cover", exclude: "name", offset: 7)

--- a/test/cases/query/fields/filter_test.rb
+++ b/test/cases/query/fields/filter_test.rb
@@ -1,0 +1,17 @@
+module IgdbClient
+  module Query
+    module Fields
+      class FilterText < ::Minitest::Test
+        describe IgdbClient::Query::Fields::Filter do
+          let(:subject) { IgdbClient::Query::Fields::Filter }
+
+          describe "#field" do
+            it "appends a semicolon but otherwise does not validate the input" do
+              assert_equal subject.new("where rating >= 80").field, "where rating >= 80;"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #9 .  Naively support the IGDB API's advanced `filters` feature.  Currently accepts any input unless used in conjunction with an `id` field.  This leaves it up to the IGDB API itself to either accept or reject the user query.  May enhance this with some guardrails in the future but for now it should be an OK implementation.