### PR TITLE
Support GameType Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Internet Game Database Client Changelog
 
+# 2.6.1
+- Support ruby 3.4.7
+- Add `game_type` endpoint
+
 ## 2.6.0
 - Support ruby 3.3.6
 - Make OpenStruct an explicit dependency

--- a/lib/igdb_client/constants/endpoints.rb
+++ b/lib/igdb_client/constants/endpoints.rb
@@ -27,6 +27,7 @@ module IgdbClient
       GAME_ENGINE_LOGOS = :game_engine_logos
       GAME_LOCALIZATIONS = :game_localizations
       GAME_MODES = :game_modes
+      GAME_TYPES = :game_types
       GAME_VERSIONS = :game_versions
       GAME_VERSION_FEATURES = :game_version_features
       GAME_VERSION_FEATURE_VALUES = :game_version_feature_values
@@ -84,6 +85,7 @@ module IgdbClient
         GAME_ENGINE_LOGOS,
         GAME_LOCALIZATIONS,
         GAME_MODES,
+        GAME_TYPES,
         GAME_VERSIONS,
         GAME_VERSION_FEATURES,
         GAME_VERSION_FEATURE_VALUES,

--- a/lib/igdb_client/version.rb
+++ b/lib/igdb_client/version.rb
@@ -1,3 +1,3 @@
 module IgdbClient
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end


### PR DESCRIPTION
```ruby
IgdbClient::Api.new.get(:game_types, limit: 100).sort_by(&:id).map(&:type)
=> 
["Main Game",
 "DLC",
 "Expansion",
 "Bundle",
 "Standalone Expansion",
 "Mod",
 "Episode",
 "Season",
 "Remake",
 "Remaster",
 "Expanded Game",
 "Port",
 "Fork",
 "Pack / Addon",
 "Update"]
```